### PR TITLE
Fix ylim of position plots

### DIFF
--- a/src/I2MC/plot/plot.py
+++ b/src/I2MC/plot/plot.py
@@ -73,9 +73,9 @@ def data_and_fixations(data, fix, fix_as_line=True, unit='pixels', res=None):
     ax2.set_xlabel('Time (ms)')
     ax2.set_ylabel('Vertical position ({})'.format(unit), size = myLabelSize)
     if isinstance(res[1],list):
-        ax1.set_ylim([res[1][0], res[1][1]])
+        ax2.set_ylim([res[1][0], res[1][1]])
     else:
-        ax1.set_ylim([0, res[1]])
+        ax2.set_ylim([0, res[1]])
 
     ### Plot X position
     Xdatp = np.atleast_2d(Xdat)


### PR DESCRIPTION
Fixes a typo introduced in 354c3b4, where horizontal position ylim was overwritten by the vertical position ylim. This resulted in the vertical position plot taking the ylim of the horizontal position plot, and the vertical position plot automatically adjusting its ylim based on the data.

You can easily test and confirm this change on the Jupyter Notebook.